### PR TITLE
Fix/logger home dir

### DIFF
--- a/wps-office-mcp/src/utils/logger.ts
+++ b/wps-office-mcp/src/utils/logger.ts
@@ -28,11 +28,45 @@ const wangFormat = winston.format.printf(({ level, message, timestamp, ...meta }
 });
 
 /**
+ * 解析布尔环境变量
+ */
+const isEnvTrue = (value?: string): boolean => {
+  if (!value) return false;
+  return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+};
+
+/**
  * 创建Logger实例
  */
 const createLogger = (name: string): winston.Logger => {
   const homeDir = process.env.HOME || process.env.USERPROFILE || require('os').homedir();
   const logDir = path.join(homeDir, '.wps-office-mcp', 'logs');
+  // MCP 默认走 stdio 协议，stdout 必须保持纯净；仅在显式开启时才输出 Console 日志
+  const enableConsoleLog = isEnvTrue(process.env.MCP_CONSOLE_LOG);
+  const transports: winston.transport[] = [
+    // 文件输出 - 错误单独记录，出问题好找
+    new winston.transports.File({
+      filename: path.join(logDir, 'error.log'),
+      level: 'error',
+    }),
+    // 所有日志
+    new winston.transports.File({
+      filename: path.join(logDir, 'combined.log'),
+    }),
+  ];
+
+  if (enableConsoleLog) {
+    transports.unshift(
+      new winston.transports.Console({
+        format: winston.format.combine(
+          winston.format.colorize({ all: true }),
+          winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+          wangFormat
+        ),
+      })
+    );
+  }
+
   return winston.createLogger({
     level: process.env.LOG_LEVEL || 'info',
     format: winston.format.combine(
@@ -41,25 +75,7 @@ const createLogger = (name: string): winston.Logger => {
       wangFormat
     ),
     defaultMeta: { service: name },
-    transports: [
-      // 控制台输出 - 带颜色，看着舒服
-      new winston.transports.Console({
-        format: winston.format.combine(
-          winston.format.colorize({ all: true }),
-          winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-          wangFormat
-        ),
-      }),
-      // 文件输出 - 错误单独记录，出问题好找
-      new winston.transports.File({
-        filename: path.join(logDir, 'error.log'),
-        level: 'error',
-      }),
-      // 所有日志
-      new winston.transports.File({
-        filename: path.join(logDir, 'combined.log'),
-      }),
-    ],
+    transports,
   });
 };
 

--- a/wps-office-mcp/src/utils/logger.ts
+++ b/wps-office-mcp/src/utils/logger.ts
@@ -31,6 +31,8 @@ const wangFormat = winston.format.printf(({ level, message, timestamp, ...meta }
  * 创建Logger实例
  */
 const createLogger = (name: string): winston.Logger => {
+  const homeDir = process.env.HOME || process.env.USERPROFILE || require('os').homedir();
+  const logDir = path.join(homeDir, '.wps-office-mcp', 'logs');
   return winston.createLogger({
     level: process.env.LOG_LEVEL || 'info',
     format: winston.format.combine(
@@ -50,12 +52,12 @@ const createLogger = (name: string): winston.Logger => {
       }),
       // 文件输出 - 错误单独记录，出问题好找
       new winston.transports.File({
-        filename: path.join(process.cwd(), 'logs', 'error.log'),
+        filename: path.join(logDir, 'error.log'),
         level: 'error',
       }),
       // 所有日志
       new winston.transports.File({
-        filename: path.join(process.cwd(), 'logs', 'combined.log'),
+        filename: path.join(logDir, 'combined.log'),
       }),
     ],
   });


### PR DESCRIPTION
## Summary
- 修复 Claude Desktop 启动 MCP 时日志目录异常问题：将日志目录基准从不可靠的运行目录改为 `os.homedir()`，统一写入 `~/.wps-office-mcp/logs/`，避免创建 `/logs` 失败导致启动报错。
- 优化 logger 行为：默认不输出 Console 日志，避免污染 MCP `stdio` 协议流。
- 新增环境变量开关 `MCP_CONSOLE_LOG`（支持 `1/true/yes/on`），便于本地调试时按需开启控制台日志。
## Changes
- 修改文件：`wps-office-mcp/src/utils/logger.ts`
- 引入布尔环境变量解析函数 `isEnvTrue`
- 重构 logger transports 组装逻辑，实现“默认文件日志 + 可选控制台日志”