### PR TITLE
Fix MCP path parameters for Word/Excel open and save tools

### DIFF
--- a/wps-office-mcp/src/tools/common/general.ts
+++ b/wps-office-mcp/src/tools/common/general.ts
@@ -135,7 +135,11 @@ export const saveAsHandler: ToolHandler = async (
   }
 
   try {
-    const params: Record<string, unknown> = { filePath };
+    const params: Record<string, unknown> = {
+      filePath,
+      path: filePath,
+      outputPath: filePath,
+    };
     if (format) {
       params.format = format.toLowerCase().replace(/^\./, '');
     }

--- a/wps-office-mcp/src/tools/excel/workbook.ts
+++ b/wps-office-mcp/src/tools/excel/workbook.ts
@@ -47,9 +47,10 @@ export const openWorkbookHandler: ToolHandler = async (
     };
   }
   try {
+    const params = { filePath, path: filePath };
     const response = await wpsClient.executeMethod<{ message: string }>(
       'openWorkbook',
-      { filePath },
+      params,
       WpsAppType.SPREADSHEET
     );
     if (!response.success) {

--- a/wps-office-mcp/src/tools/word/document.ts
+++ b/wps-office-mcp/src/tools/word/document.ts
@@ -220,13 +220,18 @@ export const openDocumentHandler: ToolHandler = async (
   }
 
   try {
+    const params = {
+      filePath,
+      path: filePath,
+    };
+
     const response = await wpsClient.executeMethod<{
       success: boolean;
       message: string;
       documentName: string;
     }>(
       'openDocument',
-      { filePath },
+      params,
       WpsAppType.WRITER
     );
 


### PR DESCRIPTION
## Summary
- align Word open tool parameters with the Mac add-in by sending both filePath and path
- align Excel open tool parameters with the Mac add-in by sending both filePath and path
- align save-as tool parameters by sending filePath, path, and outputPath to avoid false missing-path errors

## Test Plan
- [x] npm run build
- [x] npm test -- --passWithNoTests --runInBand