### PR TITLE
fix: macOS 安装脚本同时检测 wpsoffice.app 和 WPS Office.app

### DIFF
--- a/scripts/auto-install-mac.sh
+++ b/scripts/auto-install-mac.sh
@@ -51,7 +51,7 @@ check_prerequisites() {
     echo -e "${GREEN}✓ 操作系统: macOS $(sw_vers -productVersion)${NC}"
 
     # 检查 WPS Office
-    if [ ! -d "/Applications/wpsoffice.app" ]; then
+    if [ ! -d "/Applications/wpsoffice.app" ] && [ ! -d "/Applications/WPS Office.app" ]; then
         echo -e "${RED}❌ 错误: 未检测到 WPS Office${NC}"
         echo "请先安装 WPS Office for Mac: https://www.wps.cn/product/wpsmac"
         exit 1


### PR DESCRIPTION
## 问题

Mac App Store 安装的 WPS Office 路径为 `/Applications/WPS Office.app`（含空格），
与直接下载版本的 `/Applications/wpsoffice.app` 不同。
当前 `auto-install-mac.sh` 仅检查 `wpsoffice.app`，导致 App Store 版用户安装脚本预检失败。

## 修复

将单一路径检查改为双路径 OR 检查：
```
-    if [ ! -d "/Applications/wpsoffice.app" ]; then
+    if [ ! -d "/Applications/wpsoffice.app" ] && [ ! -d "/Applications/WPS Office.app" ]; then
```

## 验证

在 Mac App Store 版 WPS Office（macOS 26.4）上通过一键安装脚本验证。
