### PR TITLE
fix: handleOpenDocument 增加 null 检查，修复打开旧版 .doc 文件时崩溃

### DIFF
--- a/wps-claude-assistant/main.js
+++ b/wps-claude-assistant/main.js
@@ -1182,6 +1182,9 @@ function handleOpenDocument(params) {
     try {
         if (!params.path) return { success: false, error: '请提供文档路径' };
         var doc = Application.Documents.Open(params.path);
+        if (!doc) {
+            return { success: false, error: '无法打开文档：文件可能不存在、格式不支持或路径无效。旧版 .doc 文件请先在 WPS 中手动打开或另存为 .docx。' };
+        }
         return { success: true, data: { name: doc.Name, path: doc.FullName, paragraphs: doc.Paragraphs.Count } };
     } catch (e) {
         return { success: false, error: e.message };


### PR DESCRIPTION
## 问题

调用 `wps_word_open_document` 打开旧版 `.doc` 文件时报错：

```
打开文档失败: Cannot read properties of null (reading 'Name')
```

根因：`handleOpenDocument` 中 `Application.Documents.Open()` 返回 `null` 时，直接访问 `doc.Name` 导致空指针崩溃。

## 修复

在访问文档属性前增加 `null` 检查：

```js
var doc = Application.Documents.Open(params.path);
+ if (!doc) {
+     return { success: false, error: '无法打开文档：文件可能不存在、格式不支持或路径无效。旧版 .doc 文件请先在 WPS 中手动打开或另存为 .docx。' };
+ }
return { success: true, data: { name: doc.Name, ... } };
```

## 触发场景

- 旧版二进制 `.doc` 文件（WPS OLE2 格式）
- 文件路径不存在
- 文件格式不被 WPS 支持

## 验证

在 macOS 26.4 / WPS App Store 版上验证，打开旧版 `.doc` 文件不再是崩溃，而是返回明确错误提示。
