### PR TITLE
fix(com): 为 Get-WpsExcel/Word/Ppt 添加 New-Object + CLSID 回退，修复 COM 注册不完整时无法连接 WPS

### DIFF
--- a/wps-office-mcp/scripts/wps-com.ps1
+++ b/wps-office-mcp/scripts/wps-com.ps1
@@ -17,24 +17,71 @@ $OutputEncoding = [System.Text.Encoding]::UTF8
 
 function Get-WpsExcel {
     try { return [System.Runtime.InteropServices.Marshal]::GetActiveObject('Ket.Application') }
-    catch { return $null }
+    catch {
+        try {
+            $app = New-Object -ComObject 'Ket.Application'
+            if ($app) { return $app }
+        } catch {
+            try {
+                $clsid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\Ket.Application\CLSID' -ErrorAction Stop).'(default)'
+                if ($clsid) {
+                    $type = [Type]::GetTypeFromCLSID($clsid)
+                    if ($type) {
+                        $app = [Activator]::CreateInstance($type)
+                        if ($app) { return $app }
+                    }
+                }
+            } catch {}
+        }
+        return $null
+    }
 }
 
 function Get-WpsWord {
     try { return [System.Runtime.InteropServices.Marshal]::GetActiveObject('Kwps.Application') }
-    catch { return $null }
+    catch {
+        try {
+            $app = New-Object -ComObject 'Kwps.Application'
+            if ($app) { return $app }
+        } catch {
+            try {
+                $clsid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\Kwps.Application\CLSID' -ErrorAction Stop).'(default)'
+                if ($clsid) {
+                    $type = [Type]::GetTypeFromCLSID($clsid)
+                    if ($type) {
+                        $app = [Activator]::CreateInstance($type)
+                        if ($app) { return $app }
+                    }
+                }
+            } catch {}
+        }
+        return $null
+    }
 }
 
 function Get-WpsPpt {
     try { return [System.Runtime.InteropServices.Marshal]::GetActiveObject('Kwpp.Application') }
     catch {
-        # 活动对象取不到(演示未运行 / ROT 注册过期)时，用 CreateObject 拉起/附着 WPS 演示，
-        # 使 open/create 等操作在无打开窗口时也能工作(GetActiveObject 仅能附着前台实例，无法冷启动)。
         try {
             $app = New-Object -ComObject Kwpp.Application
             try { $app.Visible = $true } catch {}
             return $app
-        } catch { return $null }
+        } catch {
+            try {
+                $clsid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\Kwpp.Application\CLSID' -ErrorAction Stop).'(default)'
+                if ($clsid) {
+                    $type = [Type]::GetTypeFromCLSID($clsid)
+                    if ($type) {
+                        $app = [Activator]::CreateInstance($type)
+                        if ($app) {
+                            try { $app.Visible = $true } catch {}
+                            return $app
+                        }
+                    }
+                }
+            } catch {}
+        }
+        return $null
     }
 }
 

--- a/wps-office-mcp/scripts/wps-com.ps1
+++ b/wps-office-mcp/scripts/wps-com.ps1
@@ -1,4 +1,4 @@
-# Input: Action 名称与 JSON 参数
+﻿# Input: Action 名称与 JSON 参数
 # Output: WPS COM 调用结果 JSON
 # Pos: Windows COM 桥接脚本。一旦我被修改，请更新我的头部注释（Updated: 2026-05-26 15:30:00 CST），以及所属文件夹的md。
 # WPS COM Bridge - PowerShell script for WPS COM operations


### PR DESCRIPTION
## 问题

WPS 安装在非标准路径（如 D 盘）时，COM 注册可能不完整——ProgID `Ket.Application` 存在于注册表，但对应 CLSID 缺少 `LocalServer32` 子键，导致 `GetActiveObject` 和 `New-Object` 双双失败（`CO_E_CLASSSTRING` / `REGDB_E_CLASSNOTREG`）。

ps1 脚本的 `Get-WpsExcel` 和 `Get-WpsWord` 对此没有回退，直接返回 $null，导致上层 MCP 报 "WPS Excel not running"，即使 WPS 明明开着。

值得注意的是，`Get-WpsPpt` 之前已经加了 `New-Object` 回退（用于冷启动场景），但 Excel 和 Word 漏了。

## 修复

三个 Get-Wps* 函数统一为三层回退：

1. **GetActiveObject** — 附着已运行实例（不动）
2. **New-Object -ComObject** — 通过 COM 创建新实例（Excel/Word 新增，对齐 PPT 已有逻辑）
3. **CLSID 直接激活** — 从 `HKCU\Software\Classes\<ProgID>\CLSID` 运行时读取 CLSID，用 `[Type]::GetTypeFromCLSID` + `[Activator]::CreateInstance` 绕开损坏的 ProgID 映射（三个都加，作为最后一层兜底）

CLSID 从注册表动态读取而不硬编码，适配不同 WPS 版本。

## 测试

在 Windows 10 + WPS 12.1.0.24034（D 盘安装）上实测通过：
- 修复前：`GetActiveObject('Ket.Application')` → `CO_E_CLASSSTRING`，`New-Object` → `REGDB_E_CLASSNOTREG`
- 修复后：CLSID 回退成功激活 WPS，所有 MCP 操作正常

## 严重性

阻塞所有 COM 注册不完整用户的 Excel/Word 全部操作。此前仅 PPT 对此场景有容错。